### PR TITLE
feat(game-logic): implement Card and Deck classes

### DIFF
--- a/packages/game-logic/README.md
+++ b/packages/game-logic/README.md
@@ -1,0 +1,117 @@
+# Seven Poker Game Logic
+
+Pure Python implementation of Korean Seven Poker game logic.
+
+## Installation
+
+```bash
+cd packages/game-logic
+pip install -e ".[dev]"
+```
+
+## Usage
+
+### Card and Deck
+
+```python
+from game_logic import Card, Deck, Suit, Rank
+
+# Create a card
+ace_of_spades = Card(Suit.SPADE, Rank.ACE)
+print(ace_of_spades)  # A♠
+
+# Create from string notation
+card = Card.from_string("KH")  # King of Hearts
+print(card)  # K♥
+
+# Create and shuffle a deck
+deck = Deck()
+print(f"Cards remaining: {deck.remaining}")  # 52
+
+# Draw cards
+card = deck.draw()
+hand = deck.draw_many(4)
+
+# Peek without removing
+top_cards = deck.peek(3)
+
+# Reset deck
+deck.reset()
+```
+
+### Suit Rankings (Korean Seven Poker)
+
+Suits are ranked for tiebreakers:
+- Spade (♠) > Diamond (♦) > Heart (♥) > Club (♣)
+
+```python
+from game_logic import Suit
+
+# Compare suits
+assert Suit.SPADE > Suit.DIAMOND > Suit.HEART > Suit.CLUB
+
+# Get Korean names
+print(Suit.SPADE.name_ko)  # 스페이드
+```
+
+### Card Comparison
+
+Cards compare by rank first, then by suit:
+
+```python
+from game_logic import Card, Suit, Rank
+
+ace_spade = Card(Suit.SPADE, Rank.ACE)
+ace_heart = Card(Suit.HEART, Rank.ACE)
+king_spade = Card(Suit.SPADE, Rank.KING)
+
+# Ace beats King
+assert ace_heart > king_spade
+
+# Same rank: Spade beats Heart
+assert ace_spade > ace_heart
+```
+
+## Testing
+
+```bash
+pytest
+pytest --cov=game_logic
+```
+
+## API Reference
+
+### `Suit` (Enum)
+
+Card suits with Korean Seven Poker ranking.
+
+| Value | Symbol | Korean |
+|-------|--------|--------|
+| SPADE | ♠ | 스페이드 |
+| DIAMOND | ♦ | 다이아몬드 |
+| HEART | ♥ | 하트 |
+| CLUB | ♣ | 클로버 |
+
+### `Rank` (Enum)
+
+Card ranks from TWO (2) to ACE (14).
+
+### `Card`
+
+- `Card(suit: Suit, rank: Rank)` - Create a card
+- `Card.from_string(s: str)` - Parse from string (e.g., "AS", "10H")
+- `card.suit` - Get suit
+- `card.rank` - Get rank
+- Supports comparison (`<`, `>`, `==`) and hashing
+
+### `Deck`
+
+- `Deck(shuffle: bool = True)` - Create 52-card deck
+- `deck.draw()` - Draw one card
+- `deck.draw_many(n)` - Draw n cards
+- `deck.peek(n)` - Look at top n cards
+- `deck.shuffle()` - Shuffle deck
+- `deck.reset()` - Reset to full deck
+- `deck.remaining` - Cards left
+- `len(deck)` - Cards left
+- `bool(deck)` - True if cards remain

--- a/packages/game-logic/pyproject.toml
+++ b/packages/game-logic/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "seven-poker-game-logic"
+version = "0.1.0"
+description = "Game logic for Korean Seven Poker"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "Seven Poker Team" }]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-cov>=4.0", "ruff>=0.4"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/game_logic"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.coverage.run]
+source = ["src/game_logic"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]

--- a/packages/game-logic/src/game_logic/__init__.py
+++ b/packages/game-logic/src/game_logic/__init__.py
@@ -1,0 +1,6 @@
+"""Seven Poker Game Logic Package."""
+
+from .card import Card, Suit, Rank
+from .deck import Deck
+
+__all__ = ["Card", "Suit", "Rank", "Deck"]

--- a/packages/game-logic/src/game_logic/card.py
+++ b/packages/game-logic/src/game_logic/card.py
@@ -1,0 +1,175 @@
+"""Card module for Seven Poker.
+
+Defines Suit, Rank enums and Card class representing a playing card.
+"""
+
+from enum import IntEnum
+from functools import total_ordering
+
+
+class Suit(IntEnum):
+    """Card suits with Korean Seven Poker ranking.
+
+    Ranking (high to low): Spade > Diamond > Heart > Club
+    """
+
+    CLUB = 1
+    HEART = 2
+    DIAMOND = 3
+    SPADE = 4
+
+    def __str__(self) -> str:
+        symbols = {
+            Suit.SPADE: "\u2660",
+            Suit.DIAMOND: "\u2666",
+            Suit.HEART: "\u2665",
+            Suit.CLUB: "\u2663",
+        }
+        return symbols[self]
+
+    @property
+    def symbol(self) -> str:
+        """Return the Unicode symbol for this suit."""
+        return str(self)
+
+    @property
+    def name_ko(self) -> str:
+        """Return the Korean name for this suit."""
+        names = {
+            Suit.SPADE: "\uc2a4\ud398\uc774\ub4dc",
+            Suit.DIAMOND: "\ub2e4\uc774\uc544\ubab0\ub4dc",
+            Suit.HEART: "\ud558\ud2b8",
+            Suit.CLUB: "\ud074\ub85c\ubc84",
+        }
+        return names[self]
+
+
+class Rank(IntEnum):
+    """Card ranks from 2 to Ace.
+
+    Ace is highest (14) for normal comparisons.
+    For straights, Ace can also be low (handled in hand evaluation).
+    """
+
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    SIX = 6
+    SEVEN = 7
+    EIGHT = 8
+    NINE = 9
+    TEN = 10
+    JACK = 11
+    QUEEN = 12
+    KING = 13
+    ACE = 14
+
+    def __str__(self) -> str:
+        if self.value <= 10:
+            return str(self.value)
+        return {Rank.JACK: "J", Rank.QUEEN: "Q", Rank.KING: "K", Rank.ACE: "A"}[self]
+
+    @property
+    def symbol(self) -> str:
+        """Return the display symbol for this rank."""
+        return str(self)
+
+
+@total_ordering
+class Card:
+    """A playing card with suit and rank.
+
+    Cards are compared first by rank, then by suit (for tiebreakers).
+    """
+
+    __slots__ = ("_suit", "_rank")
+
+    def __init__(self, suit: Suit, rank: Rank) -> None:
+        """Create a new card.
+
+        Args:
+            suit: The card's suit.
+            rank: The card's rank.
+        """
+        self._suit = suit
+        self._rank = rank
+
+    @property
+    def suit(self) -> Suit:
+        """Return the card's suit."""
+        return self._suit
+
+    @property
+    def rank(self) -> Rank:
+        """Return the card's rank."""
+        return self._rank
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Card):
+            return NotImplemented
+        return self._suit == other._suit and self._rank == other._rank
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Card):
+            return NotImplemented
+        if self._rank != other._rank:
+            return self._rank < other._rank
+        return self._suit < other._suit
+
+    def __hash__(self) -> int:
+        return hash((self._suit, self._rank))
+
+    def __repr__(self) -> str:
+        return f"Card({self._suit.name}, {self._rank.name})"
+
+    def __str__(self) -> str:
+        return f"{self._rank}{self._suit}"
+
+    @classmethod
+    def from_string(cls, card_str: str) -> "Card":
+        """Create a card from a string like 'AS' (Ace of Spades) or '10H' (10 of Hearts).
+
+        Args:
+            card_str: String representation (rank + suit initial).
+                     Suit initials: S=Spade, D=Diamond, H=Heart, C=Club
+                     Rank: 2-10, J, Q, K, A
+
+        Returns:
+            A new Card instance.
+
+        Raises:
+            ValueError: If the string format is invalid.
+        """
+        card_str = card_str.upper().strip()
+        if len(card_str) < 2:
+            raise ValueError(f"Invalid card string: {card_str}")
+
+        suit_char = card_str[-1]
+        rank_str = card_str[:-1]
+
+        suit_map = {"S": Suit.SPADE, "D": Suit.DIAMOND, "H": Suit.HEART, "C": Suit.CLUB}
+        if suit_char not in suit_map:
+            raise ValueError(f"Invalid suit: {suit_char}")
+        suit = suit_map[suit_char]
+
+        rank_map = {
+            "2": Rank.TWO,
+            "3": Rank.THREE,
+            "4": Rank.FOUR,
+            "5": Rank.FIVE,
+            "6": Rank.SIX,
+            "7": Rank.SEVEN,
+            "8": Rank.EIGHT,
+            "9": Rank.NINE,
+            "10": Rank.TEN,
+            "J": Rank.JACK,
+            "Q": Rank.QUEEN,
+            "K": Rank.KING,
+            "A": Rank.ACE,
+        }
+        if rank_str not in rank_map:
+            raise ValueError(f"Invalid rank: {rank_str}")
+        rank = rank_map[rank_str]
+
+        return cls(suit, rank)

--- a/packages/game-logic/src/game_logic/deck.py
+++ b/packages/game-logic/src/game_logic/deck.py
@@ -1,0 +1,119 @@
+"""Deck module for Seven Poker.
+
+Defines the Deck class for managing a standard 52-card deck.
+"""
+
+import random
+from collections.abc import Iterator
+
+from .card import Card, Rank, Suit
+
+
+class Deck:
+    """A standard 52-card deck for Seven Poker.
+
+    The deck can be shuffled and cards can be drawn from it.
+    """
+
+    def __init__(self, shuffle: bool = True) -> None:
+        """Create a new deck with all 52 cards.
+
+        Args:
+            shuffle: If True, shuffle the deck after creation.
+        """
+        self._cards: list[Card] = self._create_full_deck()
+        if shuffle:
+            self.shuffle()
+
+    @staticmethod
+    def _create_full_deck() -> list[Card]:
+        """Create a list of all 52 cards in a standard deck."""
+        return [Card(suit, rank) for suit in Suit for rank in Rank]
+
+    def shuffle(self) -> None:
+        """Shuffle the deck in place using Fisher-Yates algorithm."""
+        random.shuffle(self._cards)
+
+    def draw(self) -> Card:
+        """Draw and return the top card from the deck.
+
+        Returns:
+            The top card from the deck.
+
+        Raises:
+            IndexError: If the deck is empty.
+        """
+        if not self._cards:
+            raise IndexError("Cannot draw from an empty deck")
+        return self._cards.pop()
+
+    def draw_many(self, count: int) -> list[Card]:
+        """Draw multiple cards from the deck.
+
+        Args:
+            count: Number of cards to draw.
+
+        Returns:
+            List of drawn cards.
+
+        Raises:
+            ValueError: If count is negative.
+            IndexError: If not enough cards remain.
+        """
+        if count < 0:
+            raise ValueError("Count must be non-negative")
+        if count > len(self._cards):
+            raise IndexError(
+                f"Cannot draw {count} cards, only {len(self._cards)} remaining"
+            )
+        drawn = self._cards[-count:]
+        self._cards = self._cards[:-count]
+        return list(reversed(drawn))
+
+    def reset(self, shuffle: bool = True) -> None:
+        """Reset the deck to a full 52-card deck.
+
+        Args:
+            shuffle: If True, shuffle after reset.
+        """
+        self._cards = self._create_full_deck()
+        if shuffle:
+            self.shuffle()
+
+    @property
+    def remaining(self) -> int:
+        """Return the number of cards remaining in the deck."""
+        return len(self._cards)
+
+    def __len__(self) -> int:
+        return len(self._cards)
+
+    def __bool__(self) -> bool:
+        return bool(self._cards)
+
+    def __iter__(self) -> Iterator[Card]:
+        """Iterate over remaining cards without removing them."""
+        return iter(self._cards)
+
+    def __repr__(self) -> str:
+        return f"Deck(remaining={len(self._cards)})"
+
+    def peek(self, count: int = 1) -> list[Card]:
+        """Peek at the top cards without removing them.
+
+        Args:
+            count: Number of cards to peek at.
+
+        Returns:
+            List of cards from top of deck.
+
+        Raises:
+            ValueError: If count is negative or exceeds deck size.
+        """
+        if count < 0:
+            raise ValueError("Count must be non-negative")
+        if count > len(self._cards):
+            raise ValueError(
+                f"Cannot peek {count} cards, only {len(self._cards)} remaining"
+            )
+        return list(reversed(self._cards[-count:]))

--- a/packages/game-logic/src/game_logic/deck.py
+++ b/packages/game-logic/src/game_logic/deck.py
@@ -1,6 +1,14 @@
 """Deck module for Seven Poker.
 
 Defines the Deck class for managing a standard 52-card deck.
+
+Security Warning:
+    This module uses Python's `random` module which is NOT cryptographically
+    secure. For production online poker, use `secrets` module instead.
+
+Thread Safety:
+    Deck instances are NOT thread-safe. Each game session should use its own
+    Deck instance. Do not share Deck objects across threads.
 """
 
 import random

--- a/packages/game-logic/tests/__init__.py
+++ b/packages/game-logic/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Seven Poker game logic."""

--- a/packages/game-logic/tests/test_card.py
+++ b/packages/game-logic/tests/test_card.py
@@ -1,0 +1,156 @@
+"""Tests for Card, Suit, and Rank classes."""
+
+import pytest
+
+from game_logic import Card, Rank, Suit
+
+
+class TestSuit:
+    """Tests for Suit enum."""
+
+    def test_suit_ordering(self) -> None:
+        """Suits should be ordered: Club < Heart < Diamond < Spade."""
+        assert Suit.CLUB < Suit.HEART < Suit.DIAMOND < Suit.SPADE
+
+    def test_suit_values(self) -> None:
+        """Suit values should reflect ranking."""
+        assert Suit.CLUB.value == 1
+        assert Suit.HEART.value == 2
+        assert Suit.DIAMOND.value == 3
+        assert Suit.SPADE.value == 4
+
+    def test_suit_symbols(self) -> None:
+        """Suits should have correct Unicode symbols."""
+        assert str(Suit.SPADE) == "\u2660"
+        assert str(Suit.DIAMOND) == "\u2666"
+        assert str(Suit.HEART) == "\u2665"
+        assert str(Suit.CLUB) == "\u2663"
+
+    def test_suit_korean_names(self) -> None:
+        """Suits should have correct Korean names."""
+        assert Suit.SPADE.name_ko == "\uc2a4\ud398\uc774\ub4dc"
+        assert Suit.DIAMOND.name_ko == "\ub2e4\uc774\uc544\ubab0\ub4dc"
+        assert Suit.HEART.name_ko == "\ud558\ud2b8"
+        assert Suit.CLUB.name_ko == "\ud074\ub85c\ubc84"
+
+
+class TestRank:
+    """Tests for Rank enum."""
+
+    def test_rank_ordering(self) -> None:
+        """Ranks should be ordered from 2 to Ace."""
+        assert Rank.TWO < Rank.THREE < Rank.TEN < Rank.JACK < Rank.QUEEN < Rank.KING < Rank.ACE
+
+    def test_rank_values(self) -> None:
+        """Rank values should be numeric."""
+        assert Rank.TWO.value == 2
+        assert Rank.TEN.value == 10
+        assert Rank.JACK.value == 11
+        assert Rank.QUEEN.value == 12
+        assert Rank.KING.value == 13
+        assert Rank.ACE.value == 14
+
+    def test_rank_string(self) -> None:
+        """Ranks should have correct string representation."""
+        assert str(Rank.TWO) == "2"
+        assert str(Rank.TEN) == "10"
+        assert str(Rank.JACK) == "J"
+        assert str(Rank.QUEEN) == "Q"
+        assert str(Rank.KING) == "K"
+        assert str(Rank.ACE) == "A"
+
+
+class TestCard:
+    """Tests for Card class."""
+
+    def test_card_creation(self) -> None:
+        """Cards should be created with suit and rank."""
+        card = Card(Suit.SPADE, Rank.ACE)
+        assert card.suit == Suit.SPADE
+        assert card.rank == Rank.ACE
+
+    def test_card_string(self) -> None:
+        """Cards should have correct string representation."""
+        assert str(Card(Suit.SPADE, Rank.ACE)) == "A\u2660"
+        assert str(Card(Suit.HEART, Rank.TEN)) == "10\u2665"
+        assert str(Card(Suit.DIAMOND, Rank.KING)) == "K\u2666"
+        assert str(Card(Suit.CLUB, Rank.TWO)) == "2\u2663"
+
+    def test_card_repr(self) -> None:
+        """Cards should have informative repr."""
+        card = Card(Suit.SPADE, Rank.ACE)
+        assert repr(card) == "Card(SPADE, ACE)"
+
+    def test_card_equality(self) -> None:
+        """Cards with same suit and rank should be equal."""
+        card1 = Card(Suit.SPADE, Rank.ACE)
+        card2 = Card(Suit.SPADE, Rank.ACE)
+        card3 = Card(Suit.HEART, Rank.ACE)
+
+        assert card1 == card2
+        assert card1 != card3
+
+    def test_card_comparison_by_rank(self) -> None:
+        """Cards should compare by rank first."""
+        ace_club = Card(Suit.CLUB, Rank.ACE)
+        king_spade = Card(Suit.SPADE, Rank.KING)
+
+        assert king_spade < ace_club
+
+    def test_card_comparison_by_suit(self) -> None:
+        """Cards with same rank should compare by suit."""
+        ace_spade = Card(Suit.SPADE, Rank.ACE)
+        ace_heart = Card(Suit.HEART, Rank.ACE)
+        ace_diamond = Card(Suit.DIAMOND, Rank.ACE)
+        ace_club = Card(Suit.CLUB, Rank.ACE)
+
+        assert ace_club < ace_heart < ace_diamond < ace_spade
+
+    def test_card_hash(self) -> None:
+        """Cards should be hashable for use in sets/dicts."""
+        card1 = Card(Suit.SPADE, Rank.ACE)
+        card2 = Card(Suit.SPADE, Rank.ACE)
+        card3 = Card(Suit.HEART, Rank.ACE)
+
+        assert hash(card1) == hash(card2)
+        assert hash(card1) != hash(card3)
+
+        card_set = {card1, card2, card3}
+        assert len(card_set) == 2
+
+    def test_card_from_string(self) -> None:
+        """Cards should be creatable from string notation."""
+        assert Card.from_string("AS") == Card(Suit.SPADE, Rank.ACE)
+        assert Card.from_string("10H") == Card(Suit.HEART, Rank.TEN)
+        assert Card.from_string("KD") == Card(Suit.DIAMOND, Rank.KING)
+        assert Card.from_string("2c") == Card(Suit.CLUB, Rank.TWO)
+
+    def test_card_from_string_invalid_suit(self) -> None:
+        """Invalid suit should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid suit"):
+            Card.from_string("AX")
+
+    def test_card_from_string_invalid_rank(self) -> None:
+        """Invalid rank should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid rank"):
+            Card.from_string("1S")
+
+    def test_card_from_string_too_short(self) -> None:
+        """Too short string should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid card string"):
+            Card.from_string("A")
+
+    def test_card_sorting(self) -> None:
+        """Cards should sort correctly."""
+        cards = [
+            Card(Suit.CLUB, Rank.ACE),
+            Card(Suit.SPADE, Rank.TWO),
+            Card(Suit.SPADE, Rank.ACE),
+            Card(Suit.HEART, Rank.ACE),
+        ]
+        sorted_cards = sorted(cards)
+
+        assert sorted_cards[0] == Card(Suit.SPADE, Rank.TWO)
+        assert sorted_cards[1] == Card(Suit.CLUB, Rank.ACE)
+        assert sorted_cards[2] == Card(Suit.HEART, Rank.ACE)
+        assert sorted_cards[3] == Card(Suit.SPADE, Rank.ACE)

--- a/packages/game-logic/tests/test_deck.py
+++ b/packages/game-logic/tests/test_deck.py
@@ -1,0 +1,182 @@
+"""Tests for Deck class."""
+
+import pytest
+
+from game_logic import Card, Deck, Rank, Suit
+
+
+class TestDeck:
+    """Tests for Deck class."""
+
+    def test_deck_creation(self) -> None:
+        """New deck should have 52 cards."""
+        deck = Deck(shuffle=False)
+        assert len(deck) == 52
+        assert deck.remaining == 52
+
+    def test_deck_contains_all_cards(self) -> None:
+        """Deck should contain all 52 unique cards."""
+        deck = Deck(shuffle=False)
+        cards = list(deck)
+        assert len(cards) == 52
+        assert len(set(cards)) == 52
+
+        for suit in Suit:
+            for rank in Rank:
+                assert Card(suit, rank) in cards
+
+    def test_deck_draw(self) -> None:
+        """Drawing should remove and return top card."""
+        deck = Deck(shuffle=False)
+        initial_count = len(deck)
+
+        card = deck.draw()
+
+        assert isinstance(card, Card)
+        assert len(deck) == initial_count - 1
+
+    def test_deck_draw_empty(self) -> None:
+        """Drawing from empty deck should raise IndexError."""
+        deck = Deck(shuffle=False)
+        for _ in range(52):
+            deck.draw()
+
+        with pytest.raises(IndexError, match="empty deck"):
+            deck.draw()
+
+    def test_deck_draw_many(self) -> None:
+        """Drawing multiple cards should work correctly."""
+        deck = Deck(shuffle=False)
+        cards = deck.draw_many(5)
+
+        assert len(cards) == 5
+        assert len(deck) == 47
+        assert all(isinstance(c, Card) for c in cards)
+
+    def test_deck_draw_many_too_many(self) -> None:
+        """Drawing more cards than available should raise IndexError."""
+        deck = Deck(shuffle=False)
+        deck.draw_many(50)
+
+        with pytest.raises(IndexError, match="Cannot draw 5 cards"):
+            deck.draw_many(5)
+
+    def test_deck_draw_many_negative(self) -> None:
+        """Drawing negative cards should raise ValueError."""
+        deck = Deck(shuffle=False)
+
+        with pytest.raises(ValueError, match="non-negative"):
+            deck.draw_many(-1)
+
+    def test_deck_shuffle(self) -> None:
+        """Shuffling should randomize card order."""
+        deck1 = Deck(shuffle=False)
+        deck2 = Deck(shuffle=False)
+
+        cards1_before = list(deck1)
+        deck1.shuffle()
+        cards1_after = list(deck1)
+
+        cards2 = list(deck2)
+
+        assert cards1_before == cards2
+        assert len(cards1_after) == 52
+        assert set(cards1_after) == set(cards1_before)
+
+    def test_deck_shuffle_randomness(self) -> None:
+        """Multiple shuffles should produce different orders (with high probability)."""
+        orders = []
+        for _ in range(10):
+            deck = Deck(shuffle=True)
+            orders.append(tuple(deck))
+
+        unique_orders = set(orders)
+        assert len(unique_orders) > 1
+
+    def test_deck_reset(self) -> None:
+        """Reset should restore deck to full 52 cards."""
+        deck = Deck(shuffle=False)
+        deck.draw_many(20)
+        assert len(deck) == 32
+
+        deck.reset(shuffle=False)
+        assert len(deck) == 52
+
+    def test_deck_bool(self) -> None:
+        """Deck should be truthy when cards remain, falsy when empty."""
+        deck = Deck(shuffle=False)
+        assert bool(deck) is True
+
+        for _ in range(52):
+            deck.draw()
+
+        assert bool(deck) is False
+
+    def test_deck_peek(self) -> None:
+        """Peek should show top cards without removing them."""
+        deck = Deck(shuffle=False)
+
+        peeked = deck.peek(3)
+        assert len(peeked) == 3
+        assert len(deck) == 52
+
+        drawn = deck.draw_many(3)
+        assert peeked == drawn
+
+    def test_deck_peek_invalid(self) -> None:
+        """Peek with invalid count should raise ValueError."""
+        deck = Deck(shuffle=False)
+
+        with pytest.raises(ValueError, match="non-negative"):
+            deck.peek(-1)
+
+        with pytest.raises(ValueError, match="Cannot peek"):
+            deck.peek(100)
+
+    def test_deck_repr(self) -> None:
+        """Deck should have informative repr."""
+        deck = Deck(shuffle=False)
+        assert repr(deck) == "Deck(remaining=52)"
+
+        deck.draw_many(10)
+        assert repr(deck) == "Deck(remaining=42)"
+
+    def test_deck_iteration(self) -> None:
+        """Iterating deck should not remove cards."""
+        deck = Deck(shuffle=False)
+
+        count = sum(1 for _ in deck)
+        assert count == 52
+        assert len(deck) == 52
+
+
+class TestDeckIntegration:
+    """Integration tests for Deck with Card."""
+
+    def test_deal_to_players(self) -> None:
+        """Simulate dealing 4 cards to 5 players."""
+        deck = Deck()
+        players = [[] for _ in range(5)]
+
+        for _ in range(4):
+            for player_hand in players:
+                player_hand.append(deck.draw())
+
+        for hand in players:
+            assert len(hand) == 4
+
+        assert len(deck) == 52 - 20
+
+    def test_seven_poker_deal_simulation(self) -> None:
+        """Simulate Seven Poker initial deal (4 cards per player, 1 discarded)."""
+        deck = Deck()
+        num_players = 5
+
+        initial_hands = [deck.draw_many(4) for _ in range(num_players)]
+
+        kept_hands = [hand[:3] for hand in initial_hands]
+
+        for hand in kept_hands:
+            assert len(hand) == 3
+
+        assert len(deck) == 52 - 20


### PR DESCRIPTION
## Summary

- Add `Card`, `Suit`, `Rank` classes for representing playing cards
- Add `Deck` class with shuffle and draw operations
- Korean Seven Poker suit ranking: Spade > Diamond > Heart > Club

## Changes

### New Files
- `packages/game-logic/src/game_logic/card.py` - Card, Suit, Rank implementation
- `packages/game-logic/src/game_logic/deck.py` - Deck with shuffle/draw
- `packages/game-logic/tests/test_card.py` - Card tests (19 tests)
- `packages/game-logic/tests/test_deck.py` - Deck tests (17 tests)
- `packages/game-logic/pyproject.toml` - Package configuration
- `packages/game-logic/README.md` - Package documentation

### Features
- **Suit enum**: Ordered by Korean Seven Poker rules with Unicode symbols and Korean names
- **Rank enum**: Values 2-14 (Ace high) with display symbols
- **Card class**: Immutable, comparable, hashable with `from_string()` parser
- **Deck class**: Fisher-Yates shuffle, draw/peek operations, reset functionality

## Testing

```bash
cd packages/game-logic
pip install -e ".[dev]"
pytest -v
```

All 36 tests pass.

## Documentation

- Added `packages/game-logic/README.md` with usage examples and API reference
- All public functions have docstrings

🤖 Generated with [Claude Code](https://claude.ai/code)