### PR TITLE
chore: improve agent prompts with explicit setup instructions

### DIFF
--- a/.claude/commands/respond-review.md
+++ b/.claude/commands/respond-review.md
@@ -29,9 +29,17 @@ You are the <agent-name> agent responding to review comments on your PR.
 ## Working Directory
 C:\Users\K\dev\github\seven-poker\.worktrees\<agent-name>
 
-## Setup
+## Setup (필수 - 순서대로 실행!)
 1. cd C:\Users\K\dev\github\seven-poker\.worktrees\<agent-name>
-2. Read CLAUDE.md - Bot Identity 섹션에 따라 GH_TOKEN과 git config 설정
+2. Git author 설정:
+   git config user.name "seven-poker-agent[bot]"
+   git config user.email "2639463+seven-poker-agent[bot]@users.noreply.github.com"
+3. 워크트리 동기화:
+   git fetch origin && git rebase origin/master
+
+## GH_TOKEN 사용법 (중요!)
+모든 gh 명령은 반드시 이 형식으로:
+GH_TOKEN=$(node "C:/Users/K/dev/github/seven-poker/scripts/generate-app-token.js") gh ...
 
 ## Your PR
 PR #<pr-number>

--- a/.claude/commands/spawn.md
+++ b/.claude/commands/spawn.md
@@ -19,12 +19,16 @@ argument-hint: <agent-name> <task-description>
 - PR_PENDING 상태면 → 에러: "에이전트가 PR 대기 중입니다. 머지 후 다시 시도하세요."
 - IDLE 또는 REVIEWING 상태면 → 진행
 
-### 3. Create/Update Worktree
+### 3. Create/Update Worktree & Sync
 ```bash
+# 먼저 메인에서 최신 master 가져오기
+git fetch origin
+
 # 기존 worktree 있으면 삭제 후 재생성
 git worktree remove .worktrees/<agent-name> --force 2>/dev/null
-git worktree add .worktrees/<agent-name> -b feature/<agent-name>/<task-slug> master
+git worktree add .worktrees/<agent-name> -b feature/<agent-name>/<task-slug> origin/master
 ```
+**중요:** `origin/master`에서 생성해야 최신 CLAUDE.md 포함됨
 
 ### 4. Create GitHub Issue
 ```bash
@@ -74,26 +78,40 @@ You are the <agent-name> agent for Seven Poker.
 ## Working Directory
 C:\Users\K\dev\github\seven-poker\.worktrees\<agent-name>
 
-## Setup (필수)
+## Setup (필수 - 순서대로 실행!)
 1. cd C:\Users\K\dev\github\seven-poker\.worktrees\<agent-name>
-2. Read CLAUDE.md - Bot Identity 섹션에 따라 GH_TOKEN과 git config 설정
-3. git fetch origin && git rebase origin/master
+2. Git author 설정:
+   git config user.name "seven-poker-agent[bot]"
+   git config user.email "2639463+seven-poker-agent[bot]@users.noreply.github.com"
+3. 워크트리 동기화:
+   git fetch origin && git rebase origin/master
+
+## GH_TOKEN 사용법 (중요!)
+모든 gh 명령은 반드시 이 형식으로:
+GH_TOKEN=$(node "C:/Users/K/dev/github/seven-poker/scripts/generate-app-token.js") gh ...
+
+예시:
+GH_TOKEN=$(node "C:/Users/K/dev/github/seven-poker/scripts/generate-app-token.js") gh pr create ...
 
 ## Your Task
 Issue #<issue-number>: <task-description>
 
 ## Development Steps
-1. Read .claude/agents/<agent-name>.md
+1. Read .claude/agents/<agent-name>.md for coding standards
 2. Implement feature with tests
-3. Commit: git add -A && git commit -m "feat(<agent-name>): <description>"
-4. Push: git push -u origin feature/<agent-name>/<task-slug>
-5. Create PR: gh pr create --base master --repo kywoo26/seven-poker --title "[<agent-name>] <title>" --body "## Summary\n..."
-6. Update state.json: state → "PR_PENDING", current_pr → PR번호
+3. Commit (amend 절대 금지!):
+   git add -A && git commit -m "feat(<agent-name>): <description>"
+4. Push:
+   git push -u origin feature/<agent-name>/<task-slug>
+5. Create PR:
+   GH_TOKEN=$(node "C:/Users/K/dev/github/seven-poker/scripts/generate-app-token.js") gh pr create --base master --repo kywoo26/seven-poker --title "[<agent-name>] <title>" --body "..."
+6. Update .claude/state.json: state → "PR_PENDING", current_pr → PR번호
 
 ## Rules
-- Only work in the worktree directory above
+- Only work in the worktree directory
 - Write tests for all functionality
 - Write detailed PR description
+- 절대 --amend, --force 사용 금지
 ```
 
 ### 7. Output


### PR DESCRIPTION
## Summary
에이전트 프롬프트 개선으로 작업 실패율 감소

## Changes
- **spawn.md**: 
  - GH_TOKEN 사용법 명시적 예시 추가
  - Git author 설정 단계 추가
  - 워크트리를 `origin/master`에서 생성하도록 변경
- **respond-review.md**: 동일한 개선사항 적용

## Why
이전 테스트에서 에이전트가:
1. 워크트리 동기화 안 됨 → Bot Identity 섹션 없음
2. GH_TOKEN export 후 별도 명령 → 토큰 미적용
3. 모호한 지시 → 반복 시도

## Test Plan
- [ ] `/spawn` 명령으로 새 작업 할당 테스트
- [ ] 봇 아이덴티티로 커밋/PR 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)